### PR TITLE
expose failover relationship scope addresses

### DIFF
--- a/src/Dhcp/DhcpServerFailoverRelationship.cs
+++ b/src/Dhcp/DhcpServerFailoverRelationship.cs
@@ -32,6 +32,10 @@ namespace Dhcp
         public byte? HotStandbyAddressesReservedPercentage { get; }
 
         private readonly List<DhcpServerIpAddress> scopeAddresses;
+
+        public IEnumerable<DhcpServerIpAddress> ScopeAddresses
+            => scopeAddresses.AsReadOnly();
+
         public IEnumerable<IDhcpServerScope> Scopes
         {
             get

--- a/src/Dhcp/IDhcpServerFailoverRelationship.cs
+++ b/src/Dhcp/IDhcpServerFailoverRelationship.cs
@@ -13,6 +13,7 @@ namespace Dhcp
         DhcpServerFailoverState PreviousState { get; }
         DhcpServerIpAddress PrimaryServerAddress { get; }
         string PrimaryServerName { get; }
+        IEnumerable<DhcpServerIpAddress> ScopeAddresses { get; }
         IEnumerable<IDhcpServerScope> Scopes { get; }
         DhcpServerIpAddress SecondaryServerAddress { get; }
         string SecondaryServerName { get; }


### PR DESCRIPTION
To allow more efficient loading of scopes (and their associated relationships)