### PR TITLE
New replicate failover

### DIFF
--- a/src/Dhcp/DhcpServerScope.cs
+++ b/src/Dhcp/DhcpServerScope.cs
@@ -362,11 +362,11 @@ namespace Dhcp
                 destinationScope.ExcludedIpRanges.AddExcludedIpRange(range);
 
             // replicate option values
-            var destOptions = ((DhcpServerScopeOptionValueCollection)destinationScope.Options).GetOptionValues(includeDnsSettingsOption: true).ToDictionary(o => o.OptionId);
-            var srcOptions = ((DhcpServerScopeOptionValueCollection)Options).GetOptionValues(includeDnsSettingsOption: true).ToDictionary(o => o.OptionId);
+            var destOptions = ((DhcpServerScopeOptionValueCollection)destinationScope.Options).GetOptionValues(includeDnsSettingsOption: true).ToDictionary(o => o.VendorName);
+            var srcOptions = ((DhcpServerScopeOptionValueCollection)Options).GetOptionValues(includeDnsSettingsOption: true).ToDictionary(o => o.VendorName);
             // remove option values
             foreach (var optionId in destOptions.Keys.Except(srcOptions.Keys))
-                destinationScope.Options.RemoveOptionValue(optionId);
+                destinationScope.Options.RemoveOptionValue(destOptions[optionId].OptionId);
             // add option values
             foreach (var optionId in srcOptions.Keys.Except(destOptions.Keys))
                 destinationScope.Options.AddOrSetOptionValue(srcOptions[optionId]);


### PR DESCRIPTION
I ran into a problem while replicating failover on scopes with multiple options with the same option ID (there can be multiple options with same option ID but with different vendor classes). Fixed it by storing the options with the vendor names being their dictionary key. 